### PR TITLE
Field in app manifest is deprecated

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,8 @@
 applications:
   - name: rabbitmq-perf-test
     path: ./target/pcf-perf-test-1.0-SNAPSHOT.jar
-    buildpack: https://github.com/cloudfoundry/java-buildpack.git
+    buildpacks: 
+      - https://github.com/cloudfoundry/java-buildpack.git
     memory: 768M
     health-check-type: process
     services: [rmq]


### PR DESCRIPTION
This change replaces the `buildpack` field in the app manifest for `buildpacks`. 
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#deprecated